### PR TITLE
Fix package exports configuration

### DIFF
--- a/.changeset/fruity-pumas-join.md
+++ b/.changeset/fruity-pumas-join.md
@@ -1,0 +1,5 @@
+---
+"cdk-cognito-m2m-proxy": patch
+---
+
+Fixing exports issue

--- a/package.json
+++ b/package.json
@@ -67,12 +67,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "exports": {
-    ".": {
-      "import": "./dist-esm/index.js",
-      "require": "./dist-cjs/index.js",
-      "types": "./dist-esm/index.d.ts"
-    }
-  },
   "packageManager": "pnpm@10.4.1"
 }


### PR DESCRIPTION
This pull request addresses an issue with the package exports configuration by removing the `exports` field from `package.json`.