### PR TITLE
feat: use positive boolean for auth header validation

### DIFF
--- a/.changeset/fuzzy-doors-work.md
+++ b/.changeset/fuzzy-doors-work.md
@@ -1,0 +1,5 @@
+---
+"cdk-cognito-m2m-proxy": major
+---
+
+Introduces a breaking change by renaming the disableAuthorizationHeaderValidation property to enableAuthorizationHeaderValidation and updates the corresponding logic to align with the new property name

--- a/README.md
+++ b/README.md
@@ -101,17 +101,11 @@ The `CognitoM2MTokenCacheProxyProps` interface provides the following configurat
 | `cacheTtl` | Duration | Time-to-live for cached tokens | Yes |
 | `cacheSize` | string | API Gateway cache size in GB (e.g., "0.5", "1.6", etc.). [See AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-caching.html). | No, default: "0.5" |
 | `namePrefix` | string | Optional prefix for resource names | No |
-| `disableAuthorizationHeaderValidation` | boolean | Flag to disable Authorization header validation | No |
+| `enableAuthorizationHeaderValidation` | boolean | Flag to enable Authorization header validation | No |
 | `customDomain` | object | Configuration for custom domain setup | No |
 
-The `customDomain` configuration accepts:
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `domainName` | string | The root domain for the API Gateway | Yes |
-| `subDomain` | string | The subdomain for the API Gateway. Used to generate the full URL and CNAME record | Yes |
-| `certificate` | Certificate | ACM certificate for the custom domain. Must be valid for the combination of subdomain and domain | Yes |
-| `hostedZone` | IHostedZone | Route 53 hosted zone for the domain | Yes |
+> [!Tip]
+OAuth2 standard recommends using the Authorization header for client credentials. Refer to [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1). Using `enableAuthorizationHeaderValidation` will enforce Authorization header. 
 
 ---
 
@@ -145,17 +139,11 @@ The `CognitoM2MWithTokenCacheProps` interface provides the following configurati
 | `cacheSize` | string | API Gateway cache size in GB (e.g., "0.5", "1.6", etc.). [See AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-caching.html). | No, default: "0.5" |
 | `namePrefix` | string | Optional prefix for resource names | No |
 | `userPoolProps` | CognitoUserPoolProps | Optional properties for custom Cognito User Pool settings | No |
-| `disableAuthorizationHeaderValidation` | boolean | Flag to disable Authorization header validation | No |
+| `enableAuthorizationHeaderValidation` | boolean | Flag to enable Authorization header validation | No |
 | `customCacheAPIDomain` | object | Configuration for custom domain setup | No |
 
-The `customCacheAPIDomain` configuration accepts:
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `domainName` | string | The root domain for the API Gateway | Yes |
-| `subDomain` | string | The subdomain for the API Gateway. Used to generate the full URL and CNAME record | Yes |
-| `certificate` | Certificate | ACM certificate for the custom domain. Must be valid for the combination of subdomain and domain | Yes |
-| `hostedZone` | IHostedZone | Route 53 hosted zone for the domain | Yes |
+> [!Tip]
+OAuth2 standard recommends using the Authorization header for client credentials. Refer to [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1). Using `enableAuthorizationHeaderValidation` will enforce Authorization header. 
 
 The construct exposes the user pool so it can be used to create app clients, resource servers, etc., as you normally would.
 

--- a/src/L2/CognitoM2MTokenCacheProxy.ts
+++ b/src/L2/CognitoM2MTokenCacheProxy.ts
@@ -75,11 +75,11 @@ export interface CognitoM2MTokenCacheProxyProps {
   };
 
   /**
-   * Flag to disable Authorization header validation.
+   * Flag to enable Authorization header validation.
    * OAuth2 standard recommends using the Authorization header for client credentials.
    * Refer to: https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
    */
-  disableAuthorizationHeaderValidation?: boolean;
+  enableAuthorizationHeaderValidation?: boolean;
 }
 
 export class CognitoM2MTokenCacheProxy extends Construct {
@@ -95,7 +95,7 @@ export class CognitoM2MTokenCacheProxy extends Construct {
       customDomain,
       cacheSize = '0.5',
       namePrefix,
-      disableAuthorizationHeaderValidation
+      enableAuthorizationHeaderValidation
     } = props;
 
     const resolvedNamePrefix = namePrefix ? `${namePrefix}-` : '';
@@ -161,14 +161,14 @@ export class CognitoM2MTokenCacheProxy extends Construct {
 
     const methodOptions = {
       requestParameters: {
-        'method.request.header.Authorization': !disableAuthorizationHeaderValidation,
+        'method.request.header.Authorization': !!enableAuthorizationHeaderValidation,
         'method.request.header.Content-Type': false,
         'method.request.querystring.scope': false,
         'method.request.querystring.grant_type': false,
         'method.request.querystring.client_secret': false,
         'method.request.querystring.client_id': false
       },
-      ...(!disableAuthorizationHeaderValidation && {
+      ...(enableAuthorizationHeaderValidation && {
         requestValidator: new RequestValidator(this, `RequestValidator-${stage}`, {
           restApi: this.api,
           requestValidatorName: `${resolvedNamePrefix}M2MTokenRequestValidator-${stage}`,

--- a/src/L3/CognitoM2MWithTokenCache.ts
+++ b/src/L3/CognitoM2MWithTokenCache.ts
@@ -76,7 +76,7 @@ export interface CognitoM2MTokenCacheProps {
    * OAuth2 standard recommends using the Authorization header for client credentials.
    * Refer to: https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
    */
-  disableAuthorizationHeaderValidation?: boolean;
+  enableAuthorizationHeaderValidation?: boolean;
 }
 
 export class CognitoM2MWithTokenCache extends Construct {
@@ -93,7 +93,7 @@ export class CognitoM2MWithTokenCache extends Construct {
       namePrefix,
       cacheSize,
       userPoolProps,
-      disableAuthorizationHeaderValidation
+      enableAuthorizationHeaderValidation
     } = props;
 
     // Resolve the name prefix (use empty string if not provided)
@@ -131,7 +131,7 @@ export class CognitoM2MWithTokenCache extends Construct {
       customDomain: customCacheAPIDomain,
       namePrefix,
       cacheSize,
-      disableAuthorizationHeaderValidation
+      enableAuthorizationHeaderValidation
     });
   }
 }

--- a/test/L2/CognitoM2MTokenCacheProxy.test.ts
+++ b/test/L2/CognitoM2MTokenCacheProxy.test.ts
@@ -92,7 +92,7 @@ describe('CognitoM2MTokenCacheProxy', () => {
       stage: 'test',
       cognitoTokenEndpointUrl: 'https://example.auth.us-east-1.amazoncognito.com/oauth2/token',
       cacheTtl: Duration.minutes(5),
-      disableAuthorizationHeaderValidation: true
+      enableAuthorizationHeaderValidation: false
     });
 
     const template = Template.fromStack(stack);
@@ -117,8 +117,8 @@ describe('CognitoM2MTokenCacheProxy', () => {
     new CognitoM2MTokenCacheProxy(stack, 'Proxy', {
       stage: 'test',
       cognitoTokenEndpointUrl: 'https://example.auth.us-east-1.amazoncognito.com/oauth2/token',
-      cacheTtl: Duration.minutes(5)
-      // disableAuthorizationHeaderValidation is omitted (defaults to false)
+      cacheTtl: Duration.minutes(5),
+      enableAuthorizationHeaderValidation: true
     });
 
     const template = Template.fromStack(stack);


### PR DESCRIPTION
This pull request introduces a breaking change by renaming the `disableAuthorizationHeaderValidation` property to `enableAuthorizationHeaderValidation` across multiple interfaces, classes, and tests. Additionally, it updates the corresponding logic to align with the new property name and its semantics. Documentation has been updated to reflect these changes and provide guidance on OAuth2 standards.

### Breaking Changes to Property Name and Logic:

* `src/L2/CognitoM2MTokenCacheProxy.ts`:
  - Renamed `disableAuthorizationHeaderValidation` to `enableAuthorizationHeaderValidation` in the `CognitoM2MTokenCacheProxyProps` interface and updated all references within the `CognitoM2MTokenCacheProxy` class. Logic now uses `!!enableAuthorizationHeaderValidation` to ensure proper boolean handling. [[1]](diffhunk://#diff-63792fe7e7317e41d9014909e3017843d46de53b074ef66e331a6cba84041e9aL78-R82) [[2]](diffhunk://#diff-63792fe7e7317e41d9014909e3017843d46de53b074ef66e331a6cba84041e9aL98-R98) [[3]](diffhunk://#diff-63792fe7e7317e41d9014909e3017843d46de53b074ef66e331a6cba84041e9aL164-R171)

* `src/L3/CognitoM2MWithTokenCache.ts`:
  - Renamed `disableAuthorizationHeaderValidation` to `enableAuthorizationHeaderValidation` in the `CognitoM2MTokenCacheProps` interface and updated all references within the `CognitoM2MWithTokenCache` class. [[1]](diffhunk://#diff-db4e665e0d63204a296e1b02f1fc342202b5cf220a1fdae3a57e62450ff2cb60L79-R79) [[2]](diffhunk://#diff-db4e665e0d63204a296e1b02f1fc342202b5cf220a1fdae3a57e62450ff2cb60L96-R96) [[3]](diffhunk://#diff-db4e665e0d63204a296e1b02f1fc342202b5cf220a1fdae3a57e62450ff2cb60L134-R134)